### PR TITLE
Fix to new InvGamma function

### DIFF
--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -342,7 +342,7 @@ def InvGamma(alpha=1, gamma=1, size=None):
     """Class factory for Inverse Gamma parameters."""
     class InvGamma(parameter.Parameter):
         _size = size
-        _prior = Function(InvGammaPrior, gamma=gamma)
+        _prior = parameter.Function(InvGammaPrior, gamma=gamma)
         _sampler = staticmethod(InvGammaSampler)
         _alpha = alpha
         _gamma = gamma


### PR DESCRIPTION
It appears that the new InvGamma function needed for the recent changes to the `enterprise` Parameter class, has a slight typo. I changed Function -> parameters.Function in InvGamm() and it seems to work correctly now. I actually was trying to investigate Issue #8 from @minyoungk99 . I did not run into an import error, but could not use the InvGamma function. It seems to work correctly now. 