### PR TITLE
Fixing reference to model_chain.shape[0] for np.randint

### DIFF
--- a/enterprise_extensions/model_utils.py
+++ b/enterprise_extensions/model_utils.py
@@ -987,7 +987,7 @@ class HyperModel(object):
         if mle:
             ind = np.argmax(model_chain[:, -4])
         else:
-            ind = np.random.randint(burn, chain.shape[0])
+            ind = np.random.randint(burn, model_chain.shape[0])
         params = {par: model_chain[ind, ct]
                   for ct, par in enumerate(self.param_names)
                   if par in pta.param_names}


### PR DESCRIPTION
Quick fix so that the random integer chosen for retrieving gaussian process realizations falls within the limits of the number of samples for a given model. Right now one could run into an issue when the Masked array for a given model is smaller than the random integer chosen.