### PR TITLE
fixed typo in OptimalStatistic object

### DIFF
--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -74,8 +74,6 @@ class OptimalStatistic(object):
         .. note:: SNR is computed as OS / OS_sig.
 
         """
-        if params is None:
-            params = self.
 
         # get matrix products
         TNrs = self.get_TNr(params=params)


### PR DESCRIPTION
Fixed a typo in the compute_os() function for the OptimalStatistic object